### PR TITLE
fix(push-group): 更改 origin 获取方式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 !.yarn/releases
 !.yarn/versions
 
+# idk if i need to add this or not
+package-lock.json
+
 # testing
 /coverage
 


### PR DESCRIPTION
原本的 origin 获取方式是直接读取请求的 `Origin` 头
但如果请求中没有包含 `Origin` 请求头，就会导致获取到的 origin 为 `null`，产生如下错误:
```jsonc
[14:52:48 wyf9@SRserver ~]$ curl -X POST "https://push.siiway.top/api/push-group/***" -H "Content-Type: application/json" -d '{
      "message": "示例message值",
      "title": "示例title值"
}'
{"status":"success","message":"接口组 SiiWaySecureRS 处理完成","total":2,"successCount":0,"failedCount":2,"details":[{"endpoint":"discord-wyf9server-private-push","status":"failed","error":"Invalid URL: null/api/push/***"},{"endpoint":"dingtalk-siiway-siiwaysecure-bot","status":"failed","error":"Invalid URL: null/api/push/***"}]}
```
因此作下面的修改:
```ts
// 之前的方式
const url = `${request.headers.get('origin')}/api/push/${endpoint.id}`

// 现在的方式
const origin = new URL(request.url).origin
const url = `${origin}/api/push/${endpoint.id}`
```

> *第一次写 ts，有错误欢迎指正*