### PR TITLE
fix: 修复注册账号前后端密码校验规则不一致问题

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -65,8 +65,6 @@ export function LoginForm(props: React.HTMLAttributes<HTMLDivElement>) {
               autoCorrect="off"
               disabled={isLoading}
               required
-              minLength={3}
-              maxLength={20}
             />
           </div>
           <div className="grid gap-1">
@@ -78,7 +76,6 @@ export function LoginForm(props: React.HTMLAttributes<HTMLDivElement>) {
               autoComplete="current-password"
               disabled={isLoading}
               required
-              minLength={8}
             />
           </div>
           <Button disabled={isLoading}>

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -65,6 +65,8 @@ export function LoginForm(props: React.HTMLAttributes<HTMLDivElement>) {
               autoCorrect="off"
               disabled={isLoading}
               required
+              minLength={3}
+              maxLength={20}
             />
           </div>
           <div className="grid gap-1">
@@ -76,6 +78,7 @@ export function LoginForm(props: React.HTMLAttributes<HTMLDivElement>) {
               autoComplete="current-password"
               disabled={isLoading}
               required
+              minLength={8}
             />
           </div>
           <Button disabled={isLoading}>

--- a/components/auth/register-form.tsx
+++ b/components/auth/register-form.tsx
@@ -112,7 +112,7 @@ export function RegisterForm(props: React.HTMLAttributes<HTMLDivElement>) {
               autoComplete="new-password"
               disabled={isLoading}
               required
-              minLength={6}
+              minLength={8}
             />
           </div>
           <div className="grid gap-1">
@@ -124,7 +124,7 @@ export function RegisterForm(props: React.HTMLAttributes<HTMLDivElement>) {
               autoComplete="new-password"
               disabled={isLoading}
               required
-              minLength={6}
+              minLength={8}
             />
           </div>
           <Button disabled={isLoading}>


### PR DESCRIPTION
## 问题描述

本 PR 修复用户名密码校验规则的不一致问题，确保前端表单验证与后端验证规则相符。

### 登录表单
```tsx
<Input 
  id="username"
  required
  // 无前端长度限制，由后端验证
/>
<Input 
  id="password"
  required
  // 无前端长度限制，由后端验证
/>
```

### 注册表单
```tsx
<Input 
  id="username"
  required
  minLength={3}
  maxLength={20}
/>
<Input 
  id="password"
  required
  minLength={8}  // 改为 8，与后端一致
/>
<Input 
  id="confirmPassword"
  required
  minLength={8}  // 改为 8，与后端一致
/>
```
