### PR TITLE
feat: 无推送渠道时提示优化

### DIFF
--- a/components/endpoint-dialog.tsx
+++ b/components/endpoint-dialog.tsx
@@ -38,6 +38,7 @@ import { Channel, ChannelType } from "@/lib/channels"
 import { CHANNEL_TEMPLATES } from "@/lib/channels"
 import { TemplateFields } from "@/components/template-fields"
 import { createEndpoint, updateEndpoint } from "@/lib/services/endpoints"
+import { useRouter } from "next/navigation"
 
 interface EndpointDialogProps {
   mode?: "create" | "edit"
@@ -78,6 +79,7 @@ export function EndpointDialog({
     getInitialTemplateType(endpoint)
   )
   const { toast } = useToast()
+  const router = useRouter()
 
   const form = useForm<NewEndpoint>({
     resolver: zodResolver(insertEndpointSchema),
@@ -182,11 +184,29 @@ export function EndpointDialog({
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
-                          {channels.map((channel) => (
-                            <SelectItem key={channel.id} value={channel.id}>
-                              {channel.name}
-                            </SelectItem>
-                          ))}
+                          {channels.length > 0 ? (
+                            <>
+                              {channels.map((channel) => (
+                                <SelectItem key={channel.id} value={channel.id}>
+                                  {channel.name}
+                                </SelectItem>
+                              ))}
+                            </>
+                          ) : (
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="ghost"
+                              className="w-full justify-start text-blue-600 hover:text-blue-700"
+                              onClick={() => {
+                                setOpen(false)
+                                router.push("/moe/channels")
+                              }}
+                            >
+                              <Plus className="h-4 w-4 mr-2" />
+                              添加新渠道
+                            </Button>
+                          )}
                         </SelectContent>
                       </Select>
                       <FormMessage />


### PR DESCRIPTION
优化：新增推送接口时，如果未创建过推送渠道，下拉框引导创建推送渠道。
before：

<img width="1104" height="774" alt="wechat_2025-10-30_235240_468" src="https://github.com/user-attachments/assets/5139be78-fb1d-4bc0-a0ba-f44ba8f0004f" />


after:

<img width="1151" height="813" alt="wechat_2025-10-30_235331_303" src="https://github.com/user-attachments/assets/ee072191-5cb9-4930-a73e-f881db0db021" />