### PR TITLE
feat: 接口组功能优化与推送测试功能优化

### DIFF
--- a/app/api/endpoint-groups/[id]/copy/route.ts
+++ b/app/api/endpoint-groups/[id]/copy/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server"
+import { auth } from "@/lib/auth"
+import { getDb } from "@/lib/db"
+import { endpointGroups, endpointToGroup } from "@/lib/db/schema/endpoint-groups"
+import { eq, and } from "drizzle-orm"
+import { generateId } from "@/lib/utils"
+import { z } from "zod"
+
+export const runtime = 'edge'
+
+const copyEndpointGroupSchema = z.object({
+  name: z.string().min(1, "名称不能为空"),
+  status: z.enum(["active", "inactive"]).optional(),
+})
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth()
+
+    const db = await getDb()
+    const { id } = await params
+    
+    const originalGroup = await db.query.endpointGroups.findFirst({
+      where: and(
+        eq(endpointGroups.id, id),
+        eq(endpointGroups.userId, session!.user!.id!)
+      )
+    })
+
+    if (!originalGroup) {
+      return NextResponse.json(
+        { error: "接口组不存在或无权访问" },
+        { status: 404 }
+      )
+    }
+
+    const body = await request.json()
+    const { name, status } = copyEndpointGroupSchema.parse(body)
+
+    const relations = await db.query.endpointToGroup.findMany({
+      where: eq(endpointToGroup.groupId, id)
+    })
+
+    const newGroupId = generateId()
+
+    await db.insert(endpointGroups).values({
+      id: newGroupId,
+      name,
+      userId: session!.user!.id!,
+      status: status ?? "inactive",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    if (relations.length > 0) {
+      await db.insert(endpointToGroup).values(
+        relations.map(relation => ({
+          endpointId: relation.endpointId,
+          groupId: newGroupId,
+        }))
+      )
+    }
+
+    return NextResponse.json({ id: newGroupId })
+  } catch (error) {
+    console.error('复制接口组失败:', error)
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.errors[0].message },
+        { status: 400 }
+      )
+    }
+    return NextResponse.json(
+      { error: '复制接口组失败' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/endpoint-groups/[id]/route.ts
+++ b/app/api/endpoint-groups/[id]/route.ts
@@ -3,8 +3,76 @@ import { auth } from "@/lib/auth"
 import { getDb } from "@/lib/db"
 import { endpointGroups, endpointToGroup } from "@/lib/db/schema/endpoint-groups"
 import { eq } from "drizzle-orm"
+import { z } from "zod"
 
 export const runtime = 'edge'
+
+const updateEndpointGroupSchema = z.object({
+  name: z.string().min(1, "名称不能为空"),
+  endpointIds: z.array(z.string()).min(1, "至少需要一个接口"),
+})
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth()
+
+    const db = await getDb()
+    const { id } = await params
+    
+    const group = await db.query.endpointGroups.findFirst({
+      where: (groups, { and, eq }) => and(
+        eq(groups.id, id),
+        eq(groups.userId, session!.user!.id!)
+      )
+    })
+
+    if (!group) {
+      return NextResponse.json(
+        { error: "接口组不存在或无权访问" },
+        { status: 404 }
+      )
+    }
+
+    const body = await request.json()
+    const validatedData = updateEndpointGroupSchema.parse(body)
+
+    // 更新接口组名称
+    await db.update(endpointGroups)
+      .set({
+        name: validatedData.name,
+        updatedAt: new Date(),
+      })
+      .where(eq(endpointGroups.id, id))
+
+    // 删除旧的关联关系
+    await db.delete(endpointToGroup).where(eq(endpointToGroup.groupId, id))
+
+    // 添加新的关联关系
+    await db.insert(endpointToGroup).values(
+      validatedData.endpointIds.map(endpointId => ({
+        groupId: id,
+        endpointId,
+      }))
+    )
+
+    return NextResponse.json({ success: true, id })
+  } catch (error) {
+    console.error('更新接口组失败:', error)
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: error.errors[0].message },
+        { status: 400 }
+      )
+    }
+    return NextResponse.json(
+      { error: '更新接口组失败' },
+      { status: 500 }
+    )
+  }
+}
 
 export async function DELETE(
   request: Request,

--- a/app/api/endpoints/[endpointId]/copy/route.ts
+++ b/app/api/endpoints/[endpointId]/copy/route.ts
@@ -1,0 +1,61 @@
+import { auth } from "@/lib/auth"
+import { getDb } from "@/lib/db"
+import { endpoints, insertEndpointSchema } from "@/lib/db/schema/endpoints"
+import { and, eq } from "drizzle-orm"
+import { NextResponse } from "next/server"
+import { generateId } from "@/lib/utils"
+import { z } from "zod"
+
+export const runtime = "edge"
+
+const copyEndpointSchema = z.object({
+  name: z.string().min(1, "名称不能为空"),
+  status: z.enum(["active", "inactive"]).optional(),
+})
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ endpointId: string }> }
+) {
+  try {
+    const db = await getDb()
+    const session = await auth()
+    if (!session?.user) {
+      return new NextResponse("Unauthorized", { status: 401 })
+    }
+
+    const { endpointId } = await params
+    const body = await req.json()
+    const { name, status } = copyEndpointSchema.parse(body)
+
+    const originalEndpoint = await db.query.endpoints.findFirst({
+      where: and(
+        eq(endpoints.id, endpointId),
+        eq(endpoints.userId, session.user.id!)
+      ),
+    })
+
+    if (!originalEndpoint) {
+      return new NextResponse("Not found", { status: 404 })
+    }
+
+    const newEndpoint = insertEndpointSchema.parse({
+      id: generateId(),
+      name,
+      channelId: originalEndpoint.channelId,
+      rule: originalEndpoint.rule,
+      userId: session.user.id!,
+      status: status ?? "inactive",
+    })
+
+    const created = await db.insert(endpoints).values(newEndpoint as any).returning()
+
+    return NextResponse.json(created[0])
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return new NextResponse(error.message, { status: 400 })
+    }
+    console.error("[ENDPOINT_COPY]", error)
+    return new NextResponse("Internal Error", { status: 500 })
+  }
+}

--- a/components/endpoint-group-dialog.tsx
+++ b/components/endpoint-group-dialog.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Plus, Loader2 } from "lucide-react"
+import { useState, useEffect } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+import { useToast } from "@/components/ui/use-toast"
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
+import { createEndpointGroup, updateEndpointGroup } from "@/lib/services/endpoint-groups"
+import { useRouter } from "next/navigation"
+import { EndpointGroupWithEndpoints } from "@/types/endpoint-group"
+import { Endpoint } from "@/lib/db/schema/endpoints"
+import { Checkbox } from "@/components/ui/checkbox"
+
+const endpointGroupSchema = z.object({
+  name: z.string().min(1, "名称不能为空"),
+  endpointIds: z.array(z.string()).min(1, "至少需要选择一个接口"),
+})
+
+type EndpointGroupFormValues = z.infer<typeof endpointGroupSchema>
+
+interface EndpointGroupDialogProps {
+  mode?: "create" | "edit"
+  group?: EndpointGroupWithEndpoints
+  availableEndpoints: Endpoint[]
+  icon?: React.ReactNode
+  onSuccess?: () => void
+}
+
+export function EndpointGroupDialog({ 
+  mode = "create", 
+  group,
+  availableEndpoints,
+  icon,
+  onSuccess,
+}: EndpointGroupDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [isPending, setIsPending] = useState(false)
+  const { toast } = useToast()
+  const router = useRouter()
+
+  const form = useForm<EndpointGroupFormValues>({
+    resolver: zodResolver(endpointGroupSchema),
+    defaultValues: {
+      name: "",
+      endpointIds: [],
+    },
+  })
+
+  useEffect(() => {
+    if (group && open && mode === "edit") {
+      form.reset({
+        name: group.name,
+        endpointIds: group.endpointIds,
+      })
+    } else if (mode === "create" && open) {
+      form.reset({
+        name: "",
+        endpointIds: [],
+      })
+    }
+  }, [group, open, mode, form])
+
+  const toggleEndpoint = (endpointId: string) => {
+    const currentIds = form.getValues("endpointIds")
+    const newIds = currentIds.includes(endpointId)
+      ? currentIds.filter(id => id !== endpointId)
+      : [...currentIds, endpointId]
+    form.setValue("endpointIds", newIds, { shouldValidate: true })
+  }
+
+  async function onSubmit(data: EndpointGroupFormValues) {
+    try {
+      setIsPending(true)
+      if (mode === "edit" && group) {
+        await updateEndpointGroup(group.id, data)
+        toast({ description: "接口组已更新" })
+      } else {
+        await createEndpointGroup(data)
+        toast({ description: "接口组已创建" })
+      }
+      setOpen(false)
+      form.reset()
+      onSuccess?.()
+      router.refresh()
+    } catch (error) {
+      console.error('Endpoint group dialog error:', error)
+      toast({
+        variant: "destructive",
+        description: error instanceof Error ? error.message : (mode === "edit" ? "更新失败，请重试" : "创建失败，请重试")
+      })
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const selectedCount = form.watch("endpointIds")?.length || 0
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {mode === "edit" ? (
+          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+            {icon}
+            编辑
+          </DropdownMenuItem>
+        ) : (
+          <Button size="sm" className="gap-2">
+            <Plus className="h-4 w-4" />
+            添加新的接口组
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[640px]">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === "edit" ? "编辑接口组" : "新建接口组"}
+          </DialogTitle>
+          <DialogDescription>
+            {mode === "edit" ? "修改现有的接口组" : "创建一个包含多个接口的接口组"}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <div className="max-h-[calc(80vh-160px)] overflow-y-auto">
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 py-4 px-1">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      接口组名称
+                      <span className="text-red-500 ml-1">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="请输入接口组名称" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              
+              <FormField
+                control={form.control}
+                name="endpointIds"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      选择接口
+                      <span className="text-red-500 ml-1">*</span>
+                    </FormLabel>
+                    <div className="text-sm text-muted-foreground mb-2">
+                      已选择 {selectedCount} 个接口
+                    </div>
+                    <div className="max-h-[300px] overflow-y-auto rounded-md border p-4">
+                      <div className="space-y-3">
+                        {availableEndpoints.length === 0 ? (
+                          <div className="text-sm text-muted-foreground text-center py-8">
+                            暂无可用接口，请先创建推送接口
+                          </div>
+                        ) : (
+                          availableEndpoints.map(endpoint => (
+                            <div key={endpoint.id} className="flex items-center space-x-3 rounded-md border p-3 hover:bg-accent transition-colors">
+                              <Checkbox
+                                checked={field.value.includes(endpoint.id)}
+                                onCheckedChange={() => toggleEndpoint(endpoint.id)}
+                              />
+                              <div className="flex-1">
+                                <div className="font-medium">{endpoint.name}</div>
+                                <div className="text-xs text-muted-foreground font-mono">{endpoint.id}</div>
+                              </div>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => setOpen(false)} type="button">
+                  取消
+                </Button>
+                <Button 
+                  type="submit"
+                  disabled={isPending}
+                >
+                  {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {mode === "edit" ? "保存修改" : "创建接口组"}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/endpoint-group-example.tsx
+++ b/components/endpoint-group-example.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle 
 } from "@/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { generateExampleBody } from "@/lib/utils"
+import { generateExampleBody } from "@/lib/generator"
 
 interface EndpointGroupExampleProps {
   group: EndpointGroupWithEndpoints | null

--- a/components/endpoint-group-table.tsx
+++ b/components/endpoint-group-table.tsx
@@ -355,7 +355,7 @@ export function EndpointGroupTable({ groups, availableEndpoints, onGroupsUpdate 
           <AlertDialogHeader>
             <AlertDialogTitle>确认删除</AlertDialogTitle>
             <AlertDialogDescription>
-              确定要删除接口组 {groupToDelete?.name} 吗？此操作不会删除组内的接口,但无法撤销。
+              确定要删除接口组 {groupToDelete?.name} 吗？此操作不会删除组内的接口，但无法撤销。
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/components/endpoint-group-table.tsx
+++ b/components/endpoint-group-table.tsx
@@ -21,6 +21,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
@@ -187,6 +193,31 @@ export function EndpointGroupTable({ groups, availableEndpoints, onGroupsUpdate 
         : "bg-red-50 text-red-700 ring-1 ring-inset ring-red-600/20"
     }`
   }
+
+  const getEndpointCountDisplay = (group: EndpointGroupWithEndpoints) => {
+    const totalCount = group.endpoints.length
+    const activeCount = group.endpoints.filter(e => e.status === "active").length
+    const inactiveCount = totalCount - activeCount
+
+    if (inactiveCount === 0) {
+      return <span>{totalCount}</span>
+    }
+
+    return (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-help">
+              {activeCount} / {totalCount}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{inactiveCount} 个接口已禁用</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
   
   return (
     <div className="space-y-4">
@@ -231,7 +262,7 @@ export function EndpointGroupTable({ groups, availableEndpoints, onGroupsUpdate 
                     {group.id}
                   </TableCell>
                   <TableCell className="font-medium">{group.name}</TableCell>
-                  <TableCell>{group.endpoints.length}</TableCell>
+                  <TableCell>{getEndpointCountDisplay(group)}</TableCell>
                   <TableCell>
                     <span className={getStatusBadgeClass(group.status)}>
                       {group.status === "active" ? "启用" : "禁用"}

--- a/components/endpoint-group-table.tsx
+++ b/components/endpoint-group-table.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Loader2, Trash, Eye, Power, Send } from "lucide-react"
+import { Loader2, Trash, Eye, Power, Send, Pencil } from "lucide-react"
 
 import {
   Table,
@@ -35,13 +35,16 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { MoreHorizontal } from "lucide-react"
+import { EndpointGroupDialog } from "./endpoint-group-dialog"
+import { Endpoint } from "@/lib/db/schema/endpoints"
 
 interface EndpointGroupTableProps {
   groups: EndpointGroupWithEndpoints[]
+  availableEndpoints: Endpoint[]
   onGroupsUpdate: () => void
 }
 
-export function EndpointGroupTable({ groups, onGroupsUpdate }: EndpointGroupTableProps) {
+export function EndpointGroupTable({ groups, availableEndpoints, onGroupsUpdate }: EndpointGroupTableProps) {
   const [searchQuery, setSearchQuery] = useState("")
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [groupToDelete, setGroupToDelete] = useState<EndpointGroupWithEndpoints | null>(null)
@@ -159,6 +162,10 @@ export function EndpointGroupTable({ groups, onGroupsUpdate }: EndpointGroupTabl
             className="h-9"
           />
         </div>
+        <EndpointGroupDialog 
+          availableEndpoints={availableEndpoints}
+          onSuccess={onGroupsUpdate}
+        />
       </div>
 
       <div className="rounded-md border">
@@ -217,6 +224,13 @@ export function EndpointGroupTable({ groups, onGroupsUpdate }: EndpointGroupTabl
                           )}
                           测试推送
                         </DropdownMenuItem>
+                        <EndpointGroupDialog 
+                          mode="edit"
+                          group={group}
+                          availableEndpoints={availableEndpoints}
+                          onSuccess={onGroupsUpdate}
+                          icon={<Pencil className="h-4 w-4 mr-2" />}
+                        />
                         <DropdownMenuItem 
                           onClick={() => handleToggleStatus(group.id)}
                           disabled={isLoading === group.id}

--- a/components/endpoints-tabs.tsx
+++ b/components/endpoints-tabs.tsx
@@ -110,6 +110,7 @@ export function EndpointsTabs({ initialEndpoints, channels }: { initialEndpoints
             ) : (
               <EndpointGroupTable 
                 groups={groups}
+                availableEndpoints={endpoints}
                 onGroupsUpdate={loadGroups}
               />
             )}

--- a/components/test-push-dialog.tsx
+++ b/components/test-push-dialog.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Loader2 } from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/components/ui/use-toast"
+
+interface TestPushDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string | React.ReactNode
+  initialContent: string
+  isTesting: boolean
+  onTest: (testData: any) => Promise<void>
+}
+
+export function TestPushDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  initialContent,
+  isTesting,
+  onTest,
+}: TestPushDialogProps) {
+  const [testContent, setTestContent] = useState(initialContent)
+  const { toast } = useToast()
+
+  // 当对话框打开或 initialContent 变化时，更新内容
+  useEffect(() => {
+    if (open) {
+      setTestContent(initialContent)
+    }
+  }, [open, initialContent])
+
+  const handleFormatJson = () => {
+    try {
+      const parsed = JSON.parse(testContent)
+      setTestContent(JSON.stringify(parsed, null, 4))
+      toast({
+        description: "JSON 格式化成功",
+      })
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        description: "无法格式化：内容不是有效的 JSON 格式",
+      })
+    }
+  }
+
+  const handleTest = async () => {
+    if (!testContent.trim()) {
+      toast({
+        variant: "destructive",
+        description: "请输入测试内容",
+      })
+      return
+    }
+
+    let testData: any
+    // 尝试解析为 JSON，如果失败则作为纯文本字符串
+    try {
+      testData = JSON.parse(testContent)
+    } catch (error) {
+      // 不是有效的 JSON，将其作为纯文本字符串使用
+      testData = testContent.trim()
+    }
+
+    try {
+      await onTest(testData)
+      onOpenChange(false)
+    } catch (error) {
+      // 错误处理由调用方负责
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-2xl">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div>{description}</div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="test-content">
+                测试内容 <span className="text-red-500">*</span>
+              </Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleFormatJson}
+              >
+                格式化 JSON
+              </Button>
+            </div>
+            <Textarea
+              id="test-content"
+              placeholder='JSON 格式: {"message": "示例消息"}&#10;或纯文本: 示例消息内容'
+              value={testContent}
+              onChange={(e) => setTestContent(e.target.value)}
+              className="font-mono text-sm min-h-[200px]"
+            />
+            <p className="text-xs text-muted-foreground">
+              支持 JSON 对象（如 {`{"message": "内容"}`}）或纯文本字符串
+            </p>
+          </div>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>取消</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isTesting || !testContent.trim()}
+            onClick={handleTest}
+          >
+            {isTesting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            确认发送
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/test-push-dialog.tsx
+++ b/components/test-push-dialog.tsx
@@ -54,6 +54,7 @@ export function TestPushDialog({
         description: "JSON 格式化成功",
       })
     } catch (error) {
+      console.error("Error formatting JSON:", error)
       toast({
         variant: "destructive",
         description: "无法格式化：内容不是有效的 JSON 格式",
@@ -76,6 +77,7 @@ export function TestPushDialog({
       testData = JSON.parse(testContent)
     } catch (error) {
       // 不是有效的 JSON，将其作为纯文本字符串使用
+      console.error("Error parsing JSON:", error)
       testData = testContent.trim()
     }
 
@@ -83,7 +85,7 @@ export function TestPushDialog({
       await onTest(testData)
       onOpenChange(false)
     } catch (error) {
-      // 错误处理由调用方负责
+      console.error("Error during test push:", error)
     }
   }
 

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground shadow-md",
+      className
+    )}
+    {...props}
+  >
+    {props.children}
+    <TooltipPrimitive.Arrow className="fill-primary" />
+  </TooltipPrimitive.Content>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/lib/services/endpoint-groups.ts
+++ b/lib/services/endpoint-groups.ts
@@ -1,5 +1,5 @@
 import { EndpointGroupWithEndpoints } from "@/types/endpoint-group"
-import { generateExampleBody } from "@/lib/utils"
+import { generateExampleBody } from "@/lib/generator"
 
 const API_URL = '/api/endpoint-groups'
 
@@ -119,10 +119,10 @@ export async function toggleEndpointGroupStatus(id: string): Promise<EndpointGro
   }
 }
 
-export async function testEndpointGroup(group: EndpointGroupWithEndpoints): Promise<any> {
+export async function testEndpointGroup(group: EndpointGroupWithEndpoints, customData?: any): Promise<any> {
   // 使用所有接口中的规则生成测试数据
   const allRules = group.endpoints.flatMap(e => e.rule ? [e.rule] : [])
-  const exampleBody = generateExampleBody(allRules.length > 0 ? allRules.join('\n') : '{}')
+  const exampleBody = customData || generateExampleBody(allRules.length > 0 ? allRules.join('\n') : '{}')
 
   const response = await fetch(`/api/push-group/${group.id}`, {
     method: 'POST',

--- a/lib/services/endpoint-groups.ts
+++ b/lib/services/endpoint-groups.ts
@@ -60,6 +60,32 @@ export async function createEndpointGroup(data: CreateEndpointGroupData): Promis
   return response.json() as Promise<{ id: string }>
 }
 
+export interface UpdateEndpointGroupData {
+  name: string
+  endpointIds: string[]
+}
+
+export async function updateEndpointGroup(id: string, data: UpdateEndpointGroupData): Promise<{ success: boolean }> {
+  if (!data.endpointIds.length) {
+    throw new Error('请至少选择一个接口')
+  }
+
+  const response = await fetch(`${API_URL}/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    const error = await response.json() as { error: string }
+    throw new Error(error.error || '更新接口组失败')
+  }
+
+  return response.json() as Promise<{ success: boolean }>
+}
+
 export async function deleteEndpointGroup(id: string): Promise<{ success: boolean }> {
   const response = await fetch(`${API_URL}/${id}`, {
     method: 'DELETE',

--- a/lib/services/endpoint-groups.ts
+++ b/lib/services/endpoint-groups.ts
@@ -138,4 +138,21 @@ export async function testEndpointGroup(group: EndpointGroupWithEndpoints): Prom
   }
 
   return response.json()
+}
+
+export async function copyEndpointGroup(id: string, name: string, status: "active" | "inactive" = "inactive"): Promise<{ id: string }> {
+  const response = await fetch(`${API_URL}/${id}/copy`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name, status }),
+  })
+
+  if (!response.ok) {
+    const error = await response.json() as { error: string }
+    throw new Error(error.error || '复制接口组失败')
+  }
+
+  return response.json() as Promise<{ id: string }>
 } 

--- a/lib/services/endpoints.ts
+++ b/lib/services/endpoints.ts
@@ -76,4 +76,19 @@ export async function getEndpoints() {
     throw new Error(error.error || '获取接口失败')
   }
   return response.json()
+}
+
+export async function copyEndpoint(id: string, name: string, status: "active" | "inactive" = "inactive") {
+  const res = await fetch(`${API_URL}/${id}/copy`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, status }),
+  })
+
+  if (!res.ok) {
+    const error = await res.json() as { error?: string }
+    throw new Error(error.error || "复制失败")
+  }
+
+  return res.json() as Promise<Endpoint>
 }   

--- a/lib/services/endpoints.ts
+++ b/lib/services/endpoints.ts
@@ -53,8 +53,8 @@ export async function toggleEndpointStatus(id: string) {
   return res.json() as Promise<Endpoint>
 }
 
-export async function testEndpoint(id: string, rule: string) {
-  const exampleBody = generateExampleBody(rule)
+export async function testEndpoint(id: string, rule: string, customData?: any) {
+  const exampleBody = customData || generateExampleBody(rule)
   const res = await fetch(`/api/push/${id}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -75,33 +75,3 @@ export async function fetchWithTimeout(url: string, options: any = {}) {
   clearTimeout(id);
   return response;
 }
-
-export function generateExampleBody(rule: string) {
-  if (!rule || typeof rule !== "string") return {};
-  
-  try {
-    // 一个简单的示例：从规则中提取可能的变量名并创建示例值
-    const matches = rule.match(/\$\{body\.([^}]+)\}/g) || [];
-    const result: Record<string, any> = {};
-    
-    matches.forEach(match => {
-      const key = match.replace(/\$\{body\.([^}]+)\}/, "$1");
-      const keys = key.split(".");
-      
-      let current = result;
-      keys.forEach((k, index) => {
-        if (index === keys.length - 1) {
-          current[k] = `示例${k}值`;
-        } else {
-          current[k] = current[k] || {};
-          current = current[k];
-        }
-      });
-    });
-    
-    return Object.keys(result).length > 0 ? result : { message: "示例消息内容" };
-  } catch (error) {
-    console.error("生成示例请求体出错:", error);
-    return { message: "示例消息内容" };
-  }
-}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
+    "@radix-ui/react-tooltip": "^1.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.6
         version: 1.2.6(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.6
+        version: 1.2.8(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -790,67 +793,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -926,24 +941,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.1.5':
     resolution: {integrity: sha512-FG5RApf4Gu+J+pHUQxXPM81oORZrKBYKUaBTylEIQ6Lz17hKVDsLbSXInfXM0giclvXbyiLXjTv42sQMATmZ0A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.1.5':
     resolution: {integrity: sha512-NX2Ar3BCquAOYpnoYNcKz14eH03XuF7SmSlPzTSSU4PJe7+gelAjxo3Y7F2m8+hLT8ZkkqElawBp7SWBdzwqQw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.1.5':
     resolution: {integrity: sha512-EQgqMiNu3mrV5eQHOIgeuh6GB5UU57tu17iFnLfBEhYfiOfyK+vleYKh2dkRVkV6ayx3eSqbIYgE7J7na4hhcA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.1.5':
     resolution: {integrity: sha512-HPULzqR/VqryQZbZME8HJE3jNFmTGcp+uRMHabFbQl63TtDPm+oCXAz3q8XyGv2AoihwNApVlur9Up7rXWRcjg==}
@@ -986,6 +1005,9 @@ packages:
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-alert-dialog@1.1.6':
     resolution: {integrity: sha512-p4XnPqgej8sZAAReCAKgz1REYZEBLR8hU9Pg27wFnCWIMc8g1ccCs0FjBcy05V15VTu8pAePw/VDYeOm/uZ6yQ==}
     peerDependencies:
@@ -1001,6 +1023,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.2':
     resolution: {integrity: sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1060,8 +1095,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.1':
     resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1089,6 +1142,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-dismissable-layer@1.1.5':
@@ -1148,6 +1214,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-label@2.1.2':
     resolution: {integrity: sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw==}
     peerDependencies:
@@ -1200,8 +1275,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.4':
     resolution: {integrity: sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1226,8 +1327,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.0.2':
     resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1274,6 +1401,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-switch@1.1.3':
     resolution: {integrity: sha512-1nc+vjEOQkJVsJtWPSiISGT6OKm4SiOdjMo+/icLxo2G4vxz1GntC5MzfL4v8ey9OEfw787QCD1y3mUv0NiFEQ==}
     peerDependencies:
@@ -1313,8 +1449,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.0':
     resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1331,6 +1489,24 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-escape-keydown@1.1.0':
     resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
     peerDependencies:
@@ -1340,8 +1516,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.0':
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1367,8 +1561,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.0':
     resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1389,8 +1601,24 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/rect@1.1.0':
     resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rollup/pluginutils@5.1.4':
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
@@ -4586,6 +4814,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.1': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-alert-dialog@1.1.6(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -4603,6 +4833,15 @@ snapshots:
   '@radix-ui/react-arrow@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -4655,7 +4894,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.8
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
   '@radix-ui/react-context@1.1.1(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -4688,6 +4939,19 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.8
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
   '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -4737,6 +5001,13 @@ snapshots:
   '@radix-ui/react-id@1.1.0(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.8
@@ -4817,10 +5088,38 @@ snapshots:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/rect': 1.1.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@radix-ui/react-portal@1.1.4(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -4837,9 +5136,28 @@ snapshots:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-slot': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.8)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
@@ -4899,6 +5217,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.8
 
+  '@radix-ui/react-slot@1.2.3(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
   '@radix-ui/react-switch@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -4950,7 +5275,33 @@ snapshots:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -4963,6 +5314,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.8
 
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
   '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.8)(react@19.0.0)
@@ -4970,7 +5336,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.8
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
   '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       react: 19.0.0
     optionalDependencies:
@@ -4989,9 +5368,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.8
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
   '@radix-ui/react-use-size@1.1.0(@types/react@19.0.8)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.8
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.0.8)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.8)(react@19.0.0)
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.8
@@ -5005,7 +5398,18 @@ snapshots:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@radix-ui/rect@1.1.0': {}
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rollup/pluginutils@5.1.4':
     dependencies:


### PR DESCRIPTION
# 接口组功能优化与推送测试功能优化

## 概述

- 增加接口组（创建、编辑）的 UI 与后端 API 支持
  <img width="2033" height="1149" alt="ScreenShot_2025-11-03_012741_298" src="https://github.com/user-attachments/assets/ce50bbb3-8636-44c9-aedf-3bc6dce61614" />


- 接口组内，友好显示被禁用的接口数量
  <img width="2078" height="744" alt="ScreenShot_2025-11-03_014854_630" src="https://github.com/user-attachments/assets/c58d8cb2-56fc-40e0-bf48-86a059abb450" />

- 增加单个接口、接口组的复制能力
  <img width="1995" height="923" alt="ScreenShot_2025-11-03_012713_740" src="https://github.com/user-attachments/assets/416b274a-26ab-40c7-9a97-30f449b54838" />

- 增加测试推送二次确认，允许自定义测试内容
  <img width="500" alt="ScreenShot_2025-11-03_012604_534" src="https://github.com/user-attachments/assets/9475cf83-5b51-476b-ada0-b3b8f37b1130" />
  <img width="1112" height="798" alt="ScreenShot_2025-11-03_012623_092" src="https://github.com/user-attachments/assets/bb266efa-0c56-43ec-b09d-a74a30cb7fe6" />



## 关键改动

### 新增 API 路由

- A app/api/endpoint-groups/[id]/copy/route.ts — 复制接口组
- A app/api/endpoints/[endpointId]/copy/route.ts — 复制单个端点

### 修改 API 路由

- M app/api/endpoint-groups/[id]/route.ts — （修改）可能添加了权限或返回结构调整（请参见文件）

### 新增组件

- A components/endpoint-group-dialog.tsx — 接口组创建/编辑对话框，支持选择多个接口并进行验证
- A components/test-push-dialog.tsx — 测试推送对话框（支持 JSON 格式化与文本模式）
- A components/ui/tooltip.tsx — 基于 Radix 的 Tooltip 包装组件

### 修改/增强的前端组件

- M components/endpoint-group-example.tsx
- M components/endpoint-group-table.tsx
- M components/endpoint-table.tsx
- M components/endpoints-tabs.tsx
  （这些文件和组件中整合或暴露了接口组相关功能、复制/测试按钮等 UI 交互）

### 服务层

- M lib/services/endpoint-groups.ts — 新增 copyEndpointGroup、testEndpointGroup 等方法并改进数据解析
- M lib/services/endpoints.ts — 新增 copyEndpoint、testEndpoint 并改进错误信息处理

### 依赖与锁文件

- M package.json — 依赖版本或新增依赖（如 Radix tooltip 相关已经存在，但有改动）
- M pnpm-lock.yaml — 锁文件更新

## 变更影响与注意点

- 数据库：无变更
- 测试：本地dev和build通过，数据库操作验证通过